### PR TITLE
[EBR2-102] Fix three simulation-lifecycle correctness bugs

### DIFF
--- a/hbp_nrp_backend/hbp_nrp_backend/rest_server/__SimulationService.py
+++ b/hbp_nrp_backend/hbp_nrp_backend/rest_server/__SimulationService.py
@@ -81,22 +81,11 @@ class SimulationService(Resource):
         :status 409: {0}
         :status 201: {1}
         """
-        # Use context manager to lock access to simulations while a new simulation is created
-        with SimulationService.comm_lock:
-            body = request.get_json(force=True)
+        body = request.get_json(force=True)
 
-            # check request fields
-            if missing_fields := [f for f in Simulation.required_request_fields if f not in body]:
-                raise NRPServicesClientErrorException(f'{" ".join(missing_fields)} not given.')
-
-            # check if another sim is running (i.e. any sim not in a final state)
-            if [s for s in simulations if not SimulationLifecycle.is_final_state(s.state)]:
-                raise NRPServicesClientErrorException(
-                    ErrorMessages.SIMULATION_ANOTHER_RUNNING_409, error_code=409)
-
-            # TODO better simulation IDs
-            # sim_id: uuid.UUID = uuid.uuid4() # then simulations must be a dict
-            sim_id: sim_id_type = len(simulations)
+        # check request fields
+        if missing_fields := [f for f in Simulation.required_request_fields if f not in body]:
+            raise NRPServicesClientErrorException(f'{" ".join(missing_fields)} not given.')
 
         sim_experiment_id = body.get('experimentID', None)
         sim_experiment_configuration = body.get('experimentConfiguration',
@@ -107,15 +96,30 @@ class SimulationService(Resource):
         ctx_id = body.get('ctxId', None)
         token = UserAuthentication.get_header_token()
 
-        sim = Simulation(sim_id,
-                         sim_experiment_id,
-                         sim_owner,
-                         experiment_configuration=sim_experiment_configuration,
-                         main_script=sim_main_script,
-                         state=sim_state,
-                         ctx_id=ctx_id,
-                         token=token)
-        simulations.append(sim)
+        # Use context manager to lock access to simulations while a new simulation is created.
+        # The running-sim check, the sim_id computation and the append MUST happen as one
+        # critical section, otherwise two concurrent POSTs can both see no running sim and
+        # both compute the same sim_id, creating two 'running' simulations and defeating the
+        # single-active-simulation 409.
+        with SimulationService.comm_lock:
+            # check if another sim is running (i.e. any sim not in a final state)
+            if [s for s in simulations if not SimulationLifecycle.is_final_state(s.state)]:
+                raise NRPServicesClientErrorException(
+                    ErrorMessages.SIMULATION_ANOTHER_RUNNING_409, error_code=409)
+
+            # TODO better simulation IDs
+            # sim_id: uuid.UUID = uuid.uuid4() # then simulations must be a dict
+            sim_id: sim_id_type = len(simulations)
+
+            sim = Simulation(sim_id,
+                             sim_experiment_id,
+                             sim_owner,
+                             experiment_configuration=sim_experiment_configuration,
+                             main_script=sim_main_script,
+                             state=sim_state,
+                             ctx_id=ctx_id,
+                             token=token)
+            simulations.append(sim)
 
         sim.state = "initialized"  # initialized transition
 

--- a/hbp_nrp_simserver/hbp_nrp_simserver/server/experiment_configuration.py
+++ b/hbp_nrp_simserver/hbp_nrp_simserver/server/experiment_configuration.py
@@ -50,15 +50,21 @@ def validate(exp_config: type_class) -> type_class:
     Validate and set default for exp_config
     :raises ValueError: when an invalid filed is found
     """
+    # The three rules below are independent: chaining them with if/elif made
+    # them mutually exclusive, so a config that already had SimulationTimeout
+    # would skip both the SimulationTimestep default and the EngineConfigs
+    # check, turning validation into a no-op. Each rule gets its own `if`.
+
     # must have SimulationTimeout otherwise set default
     if not hasattr(exp_config, "SimulationTimeout"):
         setattr(exp_config, "SimulationTimeout", 0)
+
     # must have SimulationTimestep otherwise set default
-    elif not hasattr(exp_config, "SimulationTimestep"):
+    if not hasattr(exp_config, "SimulationTimestep"):
         setattr(exp_config, "SimulationTimestep", 0.01)
 
     # must have EngineConfigs otherwise raise
-    elif not hasattr(exp_config, "EngineConfigs"):
+    if not hasattr(exp_config, "EngineConfigs"):
         raise ValueError("No EngineConfigs in experiment configuration")
 
     # must have datatransfer_grpc_engine otherwise raise

--- a/hbp_nrp_simserver/hbp_nrp_simserver/server/simulation_server_instance.py
+++ b/hbp_nrp_simserver/hbp_nrp_simserver/server/simulation_server_instance.py
@@ -189,10 +189,11 @@ class SimulationServerInstance:
 
         # terminated with an exit code.
         # positive integers can be ServerProcessExitCodes or some other exit code
-        if exited_with_server_error := (return_code > 0):
-            return_code_name = sim_server.ServerProcessExitCodes(return_code).name
-        else:
-            return_code_name = str(return_code)
+        # (e.g. 126/127 from the shell). Resolving the enum name is deferred to the
+        # guarded region below: an unknown code makes ServerProcessExitCodes() raise
+        # ValueError, and doing it here (before the try/finally) would kill this daemon
+        # monitor thread without ever calling failed() nor closing the logfile.
+        exited_with_server_error = return_code > 0
 
         try:
             if received_alien_signal or exited_with_server_error:
@@ -200,13 +201,23 @@ class SimulationServerInstance:
                 # lifecycle will call self.shutdown()
 
                 if not self.__terminating_process_event.is_set():
-                    # NOTE 
+                    # NOTE
                     # failed should never be called if the sim process has been stopped by us!
                     # It will cause a deadlock (unless there is a timeout on joining this thread)
                     # since the lifecycle will never complete the stopped transition
                     # while trying to join this thread and thus will get stuck trying to call failed.
                     self._lifecycle.failed()
         finally:
+            # defensively resolve the exit code name; codes outside
+            # ServerProcessExitCodes (e.g. 126/127) must not raise here
+            if exited_with_server_error:
+                try:
+                    return_code_name = sim_server.ServerProcessExitCodes(return_code).name
+                except ValueError:
+                    return_code_name = str(return_code)
+            else:
+                return_code_name = str(return_code)
+
             logger.debug("Simulation Server has exited with code: '%s'. Simulation ID: '%s'",
                          return_code_name, self.sim_id)
             # clean up sim process

--- a/hbp_nrp_simserver/hbp_nrp_simserver/tests/server/test_experiment_configuration.py
+++ b/hbp_nrp_simserver/hbp_nrp_simserver/tests/server/test_experiment_configuration.py
@@ -1,0 +1,87 @@
+# ---LICENSE-BEGIN - DO NOT CHANGE OR MOVE THIS HEADER
+# This file is part of the Neurorobotics Platform software
+# Copyright (C) 2014,2015,2016,2017 Human Brain Project
+# https://www.humanbrainproject.eu
+#
+# The Human Brain Project is a European Commission funded project
+# in the frame of the Horizon2020 FET Flagship plan.
+# http://ec.europa.eu/programmes/horizon2020/en/h2020-section/fet-flagships
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# ---LICENSE-END
+"""
+Unit tests for hbp_nrp_simserver.server.experiment_configuration.validate
+"""
+
+__author__ = 'NRP software team, Ugo Albanese'
+
+import unittest
+from types import SimpleNamespace
+
+import hbp_nrp_simserver.server.experiment_configuration as exp_conf
+
+
+def _data_engine():
+    return SimpleNamespace(EngineType="datatransfer_grpc_engine")
+
+
+class TestExperimentConfigurationValidate(unittest.TestCase):
+
+    def test_sets_all_defaults_when_missing(self):
+        conf = SimpleNamespace(EngineConfigs=[_data_engine()])
+
+        exp_conf.validate(conf)
+
+        self.assertEqual(conf.SimulationTimeout, 0)
+        self.assertEqual(conf.SimulationTimestep, 0.01)
+        self.assertEqual(conf.EngineConfigs[0].MQTTBroker, "localhost:1883")
+
+    def test_timestep_default_set_even_when_timeout_present(self):
+        # Regression: the old if/elif chain skipped the SimulationTimestep
+        # default (and the EngineConfigs check) whenever SimulationTimeout
+        # was already present.
+        conf = SimpleNamespace(SimulationTimeout=5, EngineConfigs=[_data_engine()])
+
+        exp_conf.validate(conf)
+
+        self.assertEqual(conf.SimulationTimeout, 5)
+        self.assertEqual(conf.SimulationTimestep, 0.01)
+
+    def test_missing_engine_configs_raises_even_when_timeout_present(self):
+        # Regression: with if/elif this check was unreachable once
+        # SimulationTimeout existed, so validation silently passed.
+        conf = SimpleNamespace(SimulationTimeout=5)
+
+        with self.assertRaises(ValueError):
+            exp_conf.validate(conf)
+
+    def test_missing_data_transfer_engine_raises(self):
+        conf = SimpleNamespace(EngineConfigs=[SimpleNamespace(EngineType="some_other_engine")])
+
+        with self.assertRaises(ValueError):
+            exp_conf.validate(conf)
+
+    def test_existing_mqtt_broker_is_preserved(self):
+        engine = SimpleNamespace(EngineType="datatransfer_grpc_engine",
+                                 MQTTBroker="broker.example:9999")
+        conf = SimpleNamespace(EngineConfigs=[engine])
+
+        exp_conf.validate(conf)
+
+        self.assertEqual(conf.EngineConfigs[0].MQTTBroker, "broker.example:9999")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hbp_nrp_simserver/hbp_nrp_simserver/tests/server/test_simulation_server_instance.py
+++ b/hbp_nrp_simserver/hbp_nrp_simserver/tests/server/test_simulation_server_instance.py
@@ -148,6 +148,15 @@ class TestSimulationServerInstance(unittest.TestCase):
         self.assertTrue(self.lifecycle_mock.failed.called)  # DO CALL failed()
         self.assertTrue(self.open_mock.return_value.close.called)
 
+    def test_monitor_thread_unknown_exit_code(self):
+        # An exit code outside ServerProcessExitCodes (e.g. 127 'command not found')
+        # must not crash the monitor thread: failed() and the logfile cleanup must
+        # still run instead of the ValueError from ServerProcessExitCodes(127).
+        self._monitor_thread_test(fail_cause=127, event_is_set=False)
+
+        self.assertTrue(self.lifecycle_mock.failed.called)  # DO CALL failed()
+        self.assertTrue(self.open_mock.return_value.close.called)
+
     def test_shutdown_not_initialized(self):
         with mock.patch.object(self.ssi, "_blocking_termination") as bt_mock:
             self.ssi.shutdown()


### PR DESCRIPTION
Fixes three related simulation-lifecycle correctness bugs. Jira: https://hbpneurorobotics.atlassian.net/browse/EBR2-102

## Changes (3 atomic commits)

**(a) Close POST /simulation duplicate-id race** — `SimulationService.post` performed the running-sim check and the `len()`-based `sim_id` computation inside `comm_lock`, but constructed the `Simulation` and appended it to `simulations` *outside* the lock. Two concurrent POSTs could both observe no running sim, both compute `sim_id=0` and both append — duplicate ids / two "running" sims, defeating the single-active-sim 409. The check, id computation, construction and append are now one critical section under `comm_lock`; body parsing and the (potentially blocking) `initialized` transition stay outside.

**(b) Survive unexpected sim-process exit codes** — `_monitor_sim_process` resolved the exit-code name via `ServerProcessExitCodes(return_code)` *before* the `try/finally`. That enum only covers 0-3, so any other positive code (e.g. 126/127 from the shell) raised `ValueError`, killing the daemon monitor thread before it could call `_lifecycle.failed()` and leaking the sim-process logfile fd. The name resolution is deferred into the `finally` block and guarded with `except ValueError`; `failed()` and the logfile close now always run. Regression test added (exit code 127).

**(c) Make `experiment_configuration.validate` rules independent** — the three rules (SimulationTimeout default, SimulationTimestep default, EngineConfigs presence) were chained with `if/elif/elif`, making them mutually exclusive. A config already carrying `SimulationTimeout` skipped both the SimulationTimestep default and the EngineConfigs check, so validation of a well-formed-but-incomplete config was a no-op. Split into three independent `if` statements; unit tests added covering defaults and the two previously-unreachable rules.

## Test / lint results

Ran targeted unit suites under the local sandbox (Python 3.14 only — the repo targets 3.8-3.10, and `nrp-client`/`transitions==0.4.1` are not installable here, so `make test`/`make devinstall` could not be run as-is; ran pytest directly with a `nrp_client` stub and modern `transitions`/`pytz`/`flask` deps):

- `test_simulation_service.py`: 5 passed (fix a)
- `test_simulation_server_instance.py`: 10 passed incl. new `test_monitor_thread_unknown_exit_code` (fix b) — new test confirmed failing on the pre-fix code
- `test_experiment_configuration.py` (new): 5 passed (fix c) — the two regression tests confirmed failing on the pre-fix if/elif code
- backend `rest_server` suite: 33 passed
- 2 failures elsewhere in the simserver suite (`test_nrp_core_wrapper::test_run_loop`, `test_simulation_server::test_main`) are pre-existing on `origin/development` and are Python-3.14 mock-strictness artifacts (`called_with` typo protection), unrelated to this change.
- pycodestyle (`.ci/pycodestylerc`): no new violations on changed files (one pre-existing trailing-whitespace violation removed). pylint: no new messages on changed lines.

**Husky acceptance gate:** NOT run here (no Docker/backend image in this sandbox). The end-to-end husky gate in `nrp-user-scripts` covers the integration paths (entrypoint, PYTHONPATH, MQTT, nrp-core) that unit tests mock — it must pass before release.