### PR TITLE
[EBR2-106] Stop caching auth failures/revocations; use a bounded TTL cache

### DIFF
--- a/hbp_nrp_backend/hbp_nrp_backend/rest_server/tests/test_user_authentication.py
+++ b/hbp_nrp_backend/hbp_nrp_backend/rest_server/tests/test_user_authentication.py
@@ -31,6 +31,7 @@ __author__ = 'NRP software team, Oliver Denninger'
 import unittest
 from unittest.mock import patch, MagicMock
 from flask import Flask
+from cachetools import TTLCache
 
 from hbp_nrp_backend.user_authentication import UserAuthentication
 
@@ -46,6 +47,11 @@ class TestUserAuthentication(unittest.TestCase):
 
     def setUp(self):
         self.__app = Flask(__name__)
+        # Auth lookups are memoized in class-level caches; clear them between
+        # tests so cached entries from one test do not leak into another.
+        with UserAuthentication._cache_lock:
+            UserAuthentication._token_owner_cache.clear()
+            UserAuthentication._experiment_access_cache.clear()
 
     def test_get_x_user_name_header(self):
         # ensure 'X-User-Name' header is used if available
@@ -107,6 +113,54 @@ class TestUserAuthentication(unittest.TestCase):
                 # If failed to 'can_access_experiment', it should default to false
                 client.can_access_experiment.side_effect = Exception('Test')
                 self.assertFalse(UserAuthentication.can_view(sim))
+
+    def test_get_token_owner_transient_failure_is_not_cached(self):
+        # A transient storage/proxy error resolves to None but must NOT be cached:
+        # once storage recovers, a later call has to resolve the owner normally.
+        with patch("hbp_nrp_backend.user_authentication.UserAuthentication.client") as client:
+            client.get_user = MagicMock(side_effect=ConnectionError('proxy down'))
+            self.assertIsNone(UserAuthentication.get_token_owner('a_token'))
+
+            # storage recovers
+            client.get_user = MagicMock(return_value={'id': 'myid'})
+            self.assertEqual(UserAuthentication.get_token_owner('a_token'), 'myid')
+
+    def test_get_token_owner_expires_after_ttl(self):
+        # Inject a cache with a controllable clock so we can advance past the TTL
+        # deterministically and prove a (now revoked) token stops resolving.
+        fake_time = [1000.0]
+        controlled_cache = TTLCache(maxsize=8, ttl=60, timer=lambda: fake_time[0])
+        with patch.object(UserAuthentication, '_token_owner_cache', controlled_cache):
+            with patch("hbp_nrp_backend.user_authentication.UserAuthentication.client") as client:
+                client.get_user = MagicMock(return_value={'id': 'myid'})
+
+                # First resolution hits the storage client and gets cached.
+                self.assertEqual(UserAuthentication.get_token_owner('a_token'), 'myid')
+                self.assertEqual(client.get_user.call_count, 1)
+
+                # Within the TTL the value is served from the cache (no new call).
+                self.assertEqual(UserAuthentication.get_token_owner('a_token'), 'myid')
+                self.assertEqual(client.get_user.call_count, 1)
+
+                # Advance beyond the TTL; the token has since been revoked at the
+                # source, so the (expired) cache must not keep it resolving.
+                fake_time[0] += 120
+                client.get_user = MagicMock(return_value=None)
+                self.assertIsNone(UserAuthentication.get_token_owner('a_token'))
+
+    def test_can_view_error_is_not_cached(self):
+        sim = FakeSimulation('Test')
+        with self.__app.test_request_context('/test',
+                                             headers={'Authorization': 'bearer my_token'}):
+            with patch("hbp_nrp_backend.user_authentication.UserAuthentication.client") as client:
+                # A transient error yields False but must NOT be cached.
+                client.can_access_experiment = MagicMock(side_effect=Exception('boom'))
+                self.assertFalse(UserAuthentication.can_view(sim))
+
+                # After recovery the access check must run again and resolve True,
+                # instead of returning a stale cached False.
+                client.can_access_experiment = MagicMock(return_value=True)
+                self.assertTrue(UserAuthentication.can_view(sim))
 
 
 if __name__ == '__main__':

--- a/hbp_nrp_backend/hbp_nrp_backend/user_authentication.py
+++ b/hbp_nrp_backend/hbp_nrp_backend/user_authentication.py
@@ -31,7 +31,9 @@ __author__ = 'NRP software team, Oliver Denninger'
 from flask_restful import reqparse
 from flask import request
 import logging
-from functools import lru_cache
+import threading
+
+from cachetools import TTLCache
 
 import hbp_nrp_backend.storage_client_api.storage_client as storage_client
 
@@ -50,6 +52,21 @@ class UserAuthentication:
     DEFAULT_OWNER = "default-owner"
     NO_TOKEN = "no_token"
     client = storage_client.StorageClient()
+
+    # Auth lookups are memoized in bounded TTL caches instead of an unbounded
+    # functools.lru_cache. The TTL makes revoked/expired tokens stop resolving
+    # once their entry ages out, and the size bound keeps the cache from growing
+    # without limit. Crucially, only successful lookups are stored: transient
+    # storage/proxy errors are never cached, so a temporary failure can no longer
+    # pin a user to "unauthenticated" (or to a stale authorization) for the whole
+    # process lifetime.
+    AUTH_CACHE_TTL = 300  # seconds; revocations take effect within this window
+    AUTH_CACHE_MAXSIZE = 1024
+
+    _token_owner_cache = TTLCache(maxsize=AUTH_CACHE_MAXSIZE, ttl=AUTH_CACHE_TTL)
+    _experiment_access_cache = TTLCache(maxsize=AUTH_CACHE_MAXSIZE, ttl=AUTH_CACHE_TTL)
+    # TTLCache is not thread-safe (reads expire entries too); guard every access.
+    _cache_lock = threading.Lock()
 
     @staticmethod
     def get_header(header_name, default_value):
@@ -92,20 +109,35 @@ class UserAuthentication:
             return token_field
 
     @staticmethod
-    @lru_cache()
     def get_token_owner(token):
         """
         Gets the owner of an authentication token
 
+        The result is memoized in a bounded TTL cache. Only a successful, non-empty
+        resolution is cached; a transient error or an unresolved token returns None
+        without being cached, so a temporary failure cannot pin the token to
+        "unauthenticated". A cached owner ages out after ``AUTH_CACHE_TTL`` seconds
+        so that revoked/expired tokens stop resolving.
+
         :param token: The authentication token
-        :return: The user's id
+        :return: The user's id, or None if it cannot be resolved
         """
+        with UserAuthentication._cache_lock:
+            if token in UserAuthentication._token_owner_cache:
+                return UserAuthentication._token_owner_cache[token]
+
         try:
             user = UserAuthentication.client.get_user(token)
-            return user['id'] if user else None
+            owner = user['id'] if user else None
         # pylint: disable=broad-except
         except (ValueError, ConnectionError):
             return None
+
+        if owner is not None:
+            with UserAuthentication._cache_lock:
+                UserAuthentication._token_owner_cache[token] = owner
+
+        return owner
 
     @staticmethod
     def get_user():
@@ -127,10 +159,15 @@ class UserAuthentication:
         return token_owner if token_owner else username
 
     @staticmethod
-    @lru_cache()
     def __user_can_access_experiment(token, context_id, experiment_id):
         """
         Checkis if a user can access a simulation.
+
+        The result is memoized in a bounded TTL cache. Only the outcome of a
+        successful lookup is cached; if the storage call raises (transient
+        error) nothing is cached, so a temporary failure cannot lock a user out
+        of (or into) an experiment for the process lifetime. Cached entries age
+        out after ``AUTH_CACHE_TTL`` seconds so revocations take effect.
 
         :param token: The authentication token
         :param context_id: Optional context idenfifier
@@ -141,11 +178,22 @@ class UserAuthentication:
         if token == UserAuthentication.NO_TOKEN:
             return False
 
+        cache_key = (token, context_id, experiment_id)
+        with UserAuthentication._cache_lock:
+            if cache_key in UserAuthentication._experiment_access_cache:
+                return UserAuthentication._experiment_access_cache[cache_key]
+
         try:
-            return UserAuthentication.client.can_access_experiment(token, context_id, experiment_id)
+            can_access = UserAuthentication.client.can_access_experiment(
+                token, context_id, experiment_id)
         # pylint: disable=broad-except
         except Exception:
             return False
+
+        with UserAuthentication._cache_lock:
+            UserAuthentication._experiment_access_cache[cache_key] = can_access
+
+        return can_access
 
     @staticmethod
     def can_view(simulation):

--- a/hbp_nrp_backend/requirements.txt
+++ b/hbp_nrp_backend/requirements.txt
@@ -12,3 +12,6 @@ Flask-RESTful>=0.3.10
 urllib3>=1.26,<2
 requests>=2.32,<3
 cryptography>=42.0
+# Bounded TTL cache for auth-token / experiment-access memoization
+# (replaces the unbounded functools.lru_cache that cached failures forever).
+cachetools>=5.0,<8


### PR DESCRIPTION
## EBR2-106

https://hbpneurorobotics.atlassian.net/browse/EBR2-106

## Problem

`hbp_nrp_backend/user_authentication.py` memoized both `get_token_owner`
(token -> owner) and `__user_can_access_experiment` (user -> experiment
access) with an **unbounded `functools.lru_cache`** that also cached
negative/error results and successful lookups indefinitely:

- A transient storage/proxy error resolves to `None`/`False` and was
  cached **forever**, pinning a user to "unauthenticated" (or locking
  them out of an experiment) for the whole process lifetime.
- A **revoked/expired token kept working** because its successful lookup
  never expired.
- The cache was **unbounded** in size.

## Fix

Replace `lru_cache` with size-bounded **`cachetools.TTLCache`** instances
guarded by a `threading.Lock` (TTLCache is not thread-safe; reads expire
entries too, so every access is locked):

- **Only successful lookups are cached.** Transient errors and unresolved
  tokens (`None`) are never stored, so a temporary failure can no longer
  pin a user to unauthenticated.
- **TTL = 300s** (`AUTH_CACHE_TTL`) so revoked/expired tokens stop
  resolving once their entry ages out.
- **Bounded** to `AUTH_CACHE_MAXSIZE = 1024` entries.
- Public function signatures and return behaviour are **unchanged** for
  callers (`get_user`, `can_view`).

`cachetools>=5,<8` added to `hbp_nrp_backend/requirements.txt`.

## Tests

Added to `test_user_authentication.py` (caches cleared in `setUp` so
entries don't leak between tests):

- `test_get_token_owner_transient_failure_is_not_cached` — a transient
  `get_user` error returns `None` but is NOT cached; a later call
  resolves the owner.
- `test_get_token_owner_expires_after_ttl` — with a controllable clock,
  a cached owner is served within the TTL, then stops resolving once the
  TTL elapses (revocation takes effect).
- `test_can_view_error_is_not_cached` — a `can_access_experiment` error
  returns `False` but is NOT cached; a later call resolves access.

## Verification

- New unit tests **pass** on the fixed code (8/8 in the auth suite).
- Confirmed both regressions **fail on the pre-fix (`lru_cache`) code**:
  after recovery the token stayed `None` and access stayed `False`.
- `pycodestyle` (`.ci/pycodestylerc`) and `pylint` (`.ci/pylintrc`) clean
  for the added code (only pre-existing, untouched-line warnings remain).
- Sandbox can't run full `make devinstall` (nrp-client not installable),
  so the suite was run directly against the touched module. The husky
  acceptance gate covers end-to-end integration.